### PR TITLE
youtube-dl: Infer --force-ipv4 and --no-check-certificate flags.

### DIFF
--- a/wpull/app_test.py
+++ b/wpull/app_test.py
@@ -1215,6 +1215,58 @@ class TestApp(GoodAppTestCase, TempDirMixin):
         # thumbnails = tuple(glob.glob('*.jpg'))
         # self.assertTrue(thumbnails)
 
+    @unittest.skip('not a good idea to test continuously on external servers')
+    @wpull.testing.async.async_test(timeout=DEFAULT_TIMEOUT)
+    def test_propagate_ipv4_only_and_no_cert_check_to_youtube_dl(self):
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            'https://www.youtube.com/watch?v=tPEE9ZwTmy0',
+            '--warc-file', 'test',
+            '--debug',  # to capture youtube-dl arguments in the log
+            '--no-warc-compression',
+            '--youtube-dl',
+            '--inet4-only',
+            '--no-check-certificate',
+            '--output-file', 'test.log'
+            ])
+        builder = Builder(args, unit_test=True)
+
+        app = builder.build()
+        exit_code = yield From(app.run())
+
+        self.assertEqual(0, exit_code)
+
+        with open('test.log', 'rb') as test_log:
+            data = test_log.read()
+
+            self.assertTrue(re.search(b'Starting process \[\'youtube-dl.*--force-ipv4', data))
+            self.assertTrue(re.search(b'Starting process \[\'youtube-dl.*--no-check-certificate', data))
+
+    @unittest.skip('not a good idea to test continuously on external servers')
+    @wpull.testing.async.async_test(timeout=DEFAULT_TIMEOUT)
+    def test_youtube_dl_defaults_have_neither_ipv4_only_nor_no_cert_check(self):
+        arg_parser = AppArgumentParser()
+        args = arg_parser.parse_args([
+            'https://www.youtube.com/watch?v=tPEE9ZwTmy0',
+            '--warc-file', 'test',
+            '--debug',
+            '--no-warc-compression',
+            '--youtube-dl',
+            '--output-file', 'test.log'
+            ])
+        builder = Builder(args, unit_test=True)
+
+        app = builder.build()
+        exit_code = yield From(app.run())
+
+        self.assertEqual(0, exit_code)
+
+        with open('test.log', 'rb') as test_log:
+            data = test_log.read()
+
+            self.assertFalse(re.search(b'Starting process \[\'youtube-dl.*--force-ipv4', data))
+            self.assertFalse(re.search(b'Starting process \[\'youtube-dl.*--no-check-certificate', data))
+
     @wpull.testing.async.async_test(timeout=DEFAULT_TIMEOUT)
     def test_no_cache_arg(self):
         arg_parser = AppArgumentParser()

--- a/wpull/builder.py
+++ b/wpull/builder.py
@@ -1359,6 +1359,8 @@ class Builder(object):
             root_path=self._args.directory_prefix,
             user_agent=self._args.user_agent or self.default_user_agent,
             warc_recorder=self._factory.get('WARCRecorder'),
+            inet_family=self._args.inet_family,
+            check_certificate=self._args.check_certificate
         )
 
         return coprocessor


### PR DESCRIPTION
I think that if wpull's in IPv4-only mode, youtube-dl should also run in that mode to maximize consistent behavior.  Ditto for TLS certificate checks.

This PR is also motivated by a comment made by @ivan for ArchiveBot's use of youtube-dl:

```
<ivan`> btw: youtube-dl has to be run with -4 to avoid IPv6 bans on OVH and elsewhere
```