### PR TITLE
Switch from dnspython3 to dnspython

### DIFF
--- a/requirements-pypy.txt
+++ b/requirements-pypy.txt
@@ -4,5 +4,5 @@ chardet>=2.0.1
 sqlalchemy>=0.9
 namedlist>=1.3
 html5lib>=0.999
-dnspython3>=1.12
+dnspython>=1.13
 psutil>=2.0

--- a/requirements-sphinx.txt
+++ b/requirements-sphinx.txt
@@ -5,6 +5,6 @@ sqlalchemy>=0.9
 sphinxcontrib-napoleon>=0.2.6
 namedlist>=1.3
 html5lib>=0.999
-dnspython3>=1.12
+dnspython>=1.13
 psutil>=2.0
 sphinx-argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ chardet>=2.0.1
 sqlalchemy>=0.9
 namedlist>=1.3
 html5lib>=0.999
-dnspython3>=1.12
+dnspython>=1.13
 psutil>=2.0

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup_kwargs = dict(
 
 setup_kwargs['install_requires'] = [
     'tornado', 'trollius', 'chardet', 'sqlalchemy',
-    'namedlist', 'html5lib', 'dnspython3',
+    'namedlist', 'html5lib', 'dnspython>=1.13',
 ]
 
 setup_kwargs['scripts'] = ['scripts/wpull', 'scripts/wpull3']


### PR DESCRIPTION
As of 1.13.0, dnspython now uses a single source for Python 2 and Python 3.
This means dnspython is now universal and thus dnspython3 is no longer
needed.

Due to the above, bump minimum version requirement to 1.13.