### PR TITLE
Vertical instead of curved quotation marks

### DIFF
--- a/wpull/application/app.py
+++ b/wpull/application/app.py
@@ -218,7 +218,7 @@ class Application(HookableMixin):
         '''Print an invalid SSL certificate warning.'''
         _logger.info(_('A SSL certificate could not be verified.'))
         _logger.info(_('To ignore and proceed insecurely, '
-                       'use ‘--no-check-certificate’.'))
+                       'use \'--no-check-certificate\'.'))
 
     @classmethod
     def _print_crash_message(cls):

--- a/wpull/application/hook.py
+++ b/wpull/application/hook.py
@@ -150,7 +150,7 @@ class HookableMixin(object):
                     _logger.debug('Connected hook %s %s', name, func)
                     self.hook_dispatcher.connect(name, func)
                 elif self.event_dispatcher.is_registered(name):
-                    raise RuntimeError('Plugin event ‘{name}’ cannot be attached as a hook function.'.format(name=name))
+                    raise RuntimeError('Plugin event \'{name}\' cannot be attached as a hook function.'.format(name=name))
 
             elif category == PluginFunctionCategory.event and self.event_dispatcher.is_registered(name):
                 _logger.debug('Connected event %s %s', name, func)

--- a/wpull/application/tasks/plugin.py
+++ b/wpull/application/tasks/plugin.py
@@ -118,7 +118,7 @@ class PluginSetupTask(ItemTask[AppSession]):
             instance.connect_plugin(plugin_object)
 
         # TODO: raise error if any function is left unattached
-        # raise RuntimeError('Plugin function ‘{function_name}’ could not be attached to plugin hook/event ‘{name}’.'.format(name=name, function_name=func))
+        # raise RuntimeError('Plugin function \'{function_name}\' could not be attached to plugin hook/event \'{name}\'.'.format(name=name, function_name=func))
 
     @classmethod
     def _debug_log_registered_hooks(cls, session: AppSession):

--- a/wpull/converter.py
+++ b/wpull/converter.py
@@ -80,7 +80,7 @@ class BatchDocumentConverter(object):
                     link_type = None
 
         _logger.info(__(
-            _('Converting links in file ‘{filename}’ (type={type}).'),
+            _('Converting links in file \'{filename}\' (type={type}).'),
             filename=filename, type=link_type
         ))
 

--- a/wpull/pipeline/session.py
+++ b/wpull/pipeline/session.py
@@ -57,7 +57,7 @@ class ItemSession(object):
 
     def skip(self):
         '''Mark the item as processed without download.'''
-        _logger.debug(__(_('Skipping ‘{url}’.'), url=self.url_record.url))
+        _logger.debug(__(_('Skipping \'{url}\'.'), url=self.url_record.url))
         self.app_session.factory['URLTable'].check_in(self.url_record.url, Status.skipped)
 
         self._processed = True

--- a/wpull/processor/base.py
+++ b/wpull/processor/base.py
@@ -55,6 +55,6 @@ class BaseProcessorSession(object, metaclass=abc.ABCMeta):
     def _log_error(self, request, error):
         '''Log exceptions during a fetch.'''
         _logger.error(
-            _('Fetching ‘{url}’ encountered an error: {error}'),
+            _('Fetching \'{url}\' encountered an error: {error}'),
             url=request.url, error=error
         )

--- a/wpull/processor/coprocessor/phantomjs.py
+++ b/wpull/processor/coprocessor/phantomjs.py
@@ -117,7 +117,7 @@ class PhantomJSCoprocessor(object):
                 break
         else:
             _logger.warning(__(
-                _('PhantomJS failed to fetch ‘{url}’. I am sorry.'),
+                _('PhantomJS failed to fetch \'{url}\'. I am sorry.'),
                 url=request.url_info.url
             ))
 
@@ -184,7 +184,7 @@ class PhantomJSCoprocessorSession(object):
         driver = self._phantomjs_driver_factory(params=driver_params)
 
         _logger.info(__(
-            _('PhantomJS fetching ‘{url}’.'),
+            _('PhantomJS fetching \'{url}\'.'),
             url=url
         ))
 
@@ -213,7 +213,7 @@ class PhantomJSCoprocessorSession(object):
                 self._add_warc_snapshot(path, url)
 
         _logger.info(__(
-            _('PhantomJS fetched ‘{url}’.'),
+            _('PhantomJS fetched \'{url}\'.'),
             url=url
         ))
 

--- a/wpull/processor/coprocessor/proxy.py
+++ b/wpull/processor/coprocessor/proxy.py
@@ -120,7 +120,7 @@ class ProxyCoprocessorSession(object):
 
         if verdict:
             _logger.info(__(
-                _('Fetching ‘{url}’.'),
+                _('Fetching \'{url}\'.'),
                 url=request.url_info.url
             ))
 
@@ -144,7 +144,7 @@ class ProxyCoprocessorSession(object):
         response = self._item_session.response
 
         _logger.info(__(
-            _('Fetched ‘{url}’: {status_code} {reason}. '
+            _('Fetched \'{url}\': {status_code} {reason}. '
               'Length: {content_length} [{content_type}].'),
             url=request.url,
             status_code=response.status_code,

--- a/wpull/processor/coprocessor/youtubedl.py
+++ b/wpull/processor/coprocessor/youtubedl.py
@@ -52,12 +52,12 @@ class YoutubeDlCoprocessor(object):
         )
 
         url = item_session.url_record.url
-        _logger.info(__(_('youtube-dl fetching ‘{url}’.'), url=url))
+        _logger.info(__(_('youtube-dl fetching \'{url}\'.'), url=url))
 
         with contextlib.closing(session):
             yield from session.run()
 
-        _logger.info(__(_('youtube-dl fetched ‘{url}’.'), url=url))
+        _logger.info(__(_('youtube-dl fetched \'{url}\'.'), url=url))
 
 
 class Session(object):

--- a/wpull/processor/ftp.py
+++ b/wpull/processor/ftp.py
@@ -254,7 +254,7 @@ class FTPProcessorSession(BaseProcessorSession):
 
         Coroutine.
         '''
-        _logger.info(_('Fetching ‘{url}’.'), url=request.url)
+        _logger.info(_('Fetching \'{url}\'.'), url=request.url)
 
         self._item_session.request = request
         response = None
@@ -366,7 +366,7 @@ class FTPProcessorSession(BaseProcessorSession):
     def _log_response(self, request: Request, response: Response):
         '''Log response.'''
         _logger.info(
-            _('Fetched ‘{url}’: {reply_code} {reply_text}. '
+            _('Fetched \'{url}\': {reply_code} {reply_text}. '
                 'Length: {content_length}.'),
             url=request.url,
             reply_code=response.reply.code,

--- a/wpull/processor/web.py
+++ b/wpull/processor/web.py
@@ -201,7 +201,7 @@ class WebProcessorSession(BaseProcessorSession):
                 request))
         except REMOTE_ERRORS as error:
             _logger.error(
-                _('Fetching robots.txt for ‘{url}’ '
+                _('Fetching robots.txt for \'{url}\' '
                   'encountered an error: {error}'),
                 url=self._next_url_info.url, error=error
             )
@@ -260,7 +260,7 @@ class WebProcessorSession(BaseProcessorSession):
         Returns:
             If True, stop processing any future requests.
         '''
-        _logger.info(_('Fetching ‘{url}’.'), url=request.url)
+        _logger.info(_('Fetching \'{url}\'.'), url=request.url)
 
         response = None
 
@@ -391,7 +391,7 @@ class WebProcessorSession(BaseProcessorSession):
     def _log_response(self, request: Request, response: Response):
         '''Log response.'''
         _logger.info(
-            _('Fetched ‘{url}’: {status_code} {reason}. '
+            _('Fetched \'{url}\': {status_code} {reason}. '
                 'Length: {content_length} [{content_type}].'),
             url=request.url,
             status_code=response.status_code,

--- a/wpull/scraper/css.py
+++ b/wpull/scraper/css.py
@@ -54,7 +54,7 @@ class CSSScraper(CSSReader, BaseTextStreamScraper):
 
         except UnicodeError as error:
             _logger.warning(__(
-                _('Failed to read document at ‘{url}’: {error}'),
+                _('Failed to read document at \'{url}\': {error}'),
                 url=request.url_info.url, error=error
             ))
 

--- a/wpull/scraper/html.py
+++ b/wpull/scraper/html.py
@@ -110,7 +110,7 @@ class HTMLScraper(HTMLReader, BaseHTMLScraper):
 
         except (UnicodeError, self._html_parser.parser_error) as error:
             _logger.warning(
-                _('Failed to read document at ‘{url}’: {error}'),
+                _('Failed to read document at \'{url}\': {error}'),
                 url=request.url_info.url, error=error
             )
             result_meta_info = {}

--- a/wpull/scraper/javascript.py
+++ b/wpull/scraper/javascript.py
@@ -78,7 +78,7 @@ class JavaScriptScraper(JavaScriptReader, BaseTextStreamScraper):
 
         except UnicodeError as error:
             _logger.warning(
-                _('Failed to read document at ‘{url}’: {error}'),
+                _('Failed to read document at \'{url}\': {error}'),
                 url=request.url_info.url, error=error
             )
 

--- a/wpull/scraper/sitemap.py
+++ b/wpull/scraper/sitemap.py
@@ -39,7 +39,7 @@ class SitemapScraper(SitemapReader, BaseExtractiveScraper):
 
         except (UnicodeError, self._html_parser.parser_error) as error:
             _logger.warning(
-                _('Failed to read document at ‘{url}’: {error}'),
+                _('Failed to read document at \'{url}\': {error}'),
                 url=request.url_info.url, error=error
             )
 

--- a/wpull/scraper/util.py
+++ b/wpull/scraper/util.py
@@ -76,7 +76,7 @@ def urljoin_safe(base_url, url, allow_fragments=True):
         )
     except ValueError as error:
         _logger.warning(__(
-            _('Unable to parse URL ‘{url}’: {error}.'),
+            _('Unable to parse URL \'{url}\': {error}.'),
             url=url, error=error
         ))
 

--- a/wpull/url.py
+++ b/wpull/url.py
@@ -406,7 +406,7 @@ def parse_url_or_log(url, encoding='utf-8'):
         url_info = URLInfo.parse(url, encoding=encoding)
     except ValueError as error:
         _logger.warning(__(
-            _('Unable to parse URL ‘{url}’: {error}.'),
+            _('Unable to parse URL \'{url}\': {error}.'),
             url=wpull.string.printable_str(url), error=error))
     else:
         return url_info


### PR DESCRIPTION
This pull request implements #353.

Changes:

Curved quotation marks ‘ and ’ replaced to simple apostrophe ' so that logfiles can be parsed more easily.

Occurences of the opening ‘ has *not* been replaced in:
* `wpull/thirdparty/dammit.py` (obviously)

Occurences of the closing ’ has *not* been replaced in:
* `wpull/thirdparty/dammit.py` (obviously)
* `wpull/application/options.py` (not necessary)
* test files (obviously / not necessary):
    * `wpull/protocol/ftp/client_test.py`
    * `wpull/string_test.py`
    * `wpull/testing/ftp.py`
    * `wpull/testing/integration/ftp_test.py`
    * `wpull/testing/samples/twitchplayspokemonfirered.html`

All other occurences replaced, in 17 files total.