### PR TITLE
Tweaked CSS URL regex to deal with empty url() properties and long data URIs

### DIFF
--- a/wpull/document/css.py
+++ b/wpull/document/css.py
@@ -12,7 +12,7 @@ import wpull.util
 
 class CSSReader(BaseDocumentDetector, BaseTextStreamReader):
     '''Cascading Stylesheet Document Reader.'''
-    URL_PATTERN = r'''url\(\s*(['"]?)(.{1,500}?)(?:\1)\s*\)'''
+    URL_PATTERN = r'''url\(\s*(['"]?)(.*?)(?:\1)\s*\)'''
     IMPORT_URL_PATTERN = r'''@import\s*(?:url\()?['"]?([^\s'")]{1,500}).*?;'''
     URL_REGEX = re.compile(r'{}|{}'.format(URL_PATTERN, IMPORT_URL_PATTERN))
     BUFFER_SIZE = 1048576

--- a/wpull/scraper/html_test.py
+++ b/wpull/scraper/html_test.py
@@ -52,6 +52,7 @@ class Mixin(object):
             'http://example.com/style_import_quote_url.css',
             'http://example.com/style_single_quote_import.css',
             'http://example.com/style_double_quote_import.css',
+            'http://example.com/bg.png',
             'http://example.com/link_href.css',
             'http://example.com/script.js',
             'http://example.com/body_background.png',

--- a/wpull/testing/samples/many_urls.html
+++ b/wpull/testing/samples/many_urls.html
@@ -9,6 +9,9 @@
 @import 'style_single_quote_import.css';
 @import "style_double_quote_import.css";
 </style>
+<style>
+#emb{background-image:url();width:144px;height:144px}#nav{background-image:url("bg.png")}#foo{background-image:url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin" width="100%" height="100%"><rect width="300" height="100" style="fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)" /></svg>');width:200px;height:200px}
+</style>
 <script type="text/javascript" src="script.js"></script>
 <link rel="stylesheet" href="link_href.css">
 <meta property="og:image" content="og_image.png">


### PR DESCRIPTION
This pull request fixes #374 along with long data URIs containing parenthesis being misparsed, like [here](https://kotaku.com/yes-yes-praise-it-1821414610)

I remembered to:

* [x] Update or add unit tests if needed
* [x] Update or add documentation/comments if needed
* [x] Made sure stray files or whitespace didn't get committed
* [x] Read the guidelines for contributing

Changes:

* Replaced {1,500} with an asterisk. This helps account for empty url() paths as well as longer data URIs that happen to have parentheses in them